### PR TITLE
Bug fix: Mangling of values

### DIFF
--- a/include/RootInterface/TTreeManager.h
+++ b/include/RootInterface/TTreeManager.h
@@ -53,7 +53,7 @@ namespace Task {
             unsigned short mult;    //!< Number of entries of the detector type in event    */
             unsigned short ID[MAX_ENTRIES]; //!< ID number of the detector event.           */
             bool finishflag[MAX_ENTRIES];   //!< Pile-up flag   */
-            unsigned short adcvalue[MAX_ENTRIES]; //!< 16-bit ADC reading */
+            unsigned int adcvalue[MAX_ENTRIES]; //!< 16-bit ADC reading */
             //unsigned short cfdvalue[MAX_ENTRIES]; //!< 16-bit CFD result (obmitted for now since this should not be done afterwards...) */
             long long timestamp[MAX_ENTRIES];   //!< Timestamp in ns    */
             double energy[MAX_ENTRIES]; //!< Energy of the event    */

--- a/main.cpp
+++ b/main.cpp
@@ -89,7 +89,7 @@ std::vector<std::string> RunSort(const CLI::Options &options, ProgressUI &progre
         RootWriter::Write(hm, hist_file.c_str()/*, nullptr, "UPDATE"*/);
     }
 
-    //root_files.push_back(hist_file);
+    root_files.push_back(hist_file);
     return root_files;
 }
 

--- a/src/RootInterface/TTreeManager.cpp
+++ b/src/RootInterface/TTreeManager.cpp
@@ -62,7 +62,7 @@ details::TriggerEntry::TriggerEntry(TTree &tree)
 {
     make_leaf(&tree, &ID, "Trigger", "ID", false, 's');
     make_leaf(&tree, &finishflag, "Trigger", "FinishFlag", false, 'O');
-    make_leaf(&tree, &adcvalue, "Trigger", "ADCValue", false, 's');
+    make_leaf(&tree, &adcvalue, "Trigger", "ADCValue", false, 'i');
     make_leaf(&tree, &timestamp, "Trigger", "timestamp", false, 'L');
     make_leaf(&tree, &energy, "Trigger", "energy", false, 'D');
     make_leaf(&tree, &cfdfail, "Trigger", "CFDfail", false, 'O');
@@ -77,7 +77,7 @@ details::DetectorEntries::DetectorEntries(TTree &tree, const char *base_name)
     make_leaf(&tree, &mult, base_name, "Mult", false, 's');
     make_leaf(&tree, ID, base_name, "ID", true, 's');
     make_leaf(&tree, finishflag, base_name, "FinishFlag", true, 'O');
-    make_leaf(&tree, adcvalue, base_name, "ADCValue", true, 's');
+    make_leaf(&tree, adcvalue, base_name, "ADCValue", true, 'i');
     make_leaf(&tree, timestamp, base_name, "timestamp", true, 'L');
     make_leaf(&tree, energy, base_name, "energy", true, 'D');
     make_leaf(&tree, cfdfail, base_name, "CFDfail", true, 'O');


### PR DESCRIPTION
ROOT somehow mangles the data. Probably it somehow assumes its a signed integer. Anyways, increased the word size to 32-bit which fixes the issue. This is not ideal, as 16-bit is exactly the size of the actual data, and would perfectly represent all possible values.